### PR TITLE
del listeners queue

### DIFF
--- a/src/SerialPort.ts
+++ b/src/SerialPort.ts
@@ -43,13 +43,12 @@ export interface ListenerProxy {
 class SerialPort {
   private path: string;
   private eventEmitter: any;
-  private listeners: ListenerProxy[];
   private subscriptions: EventSubscription[];
 
   constructor(serialPort: SerialPortWrapper, eventEmitter: EventEmitter) {
     this.path = serialPort.path;
     this.eventEmitter = eventEmitter;
-    this.listeners = [];
+   
     this.subscriptions = [];
   }
 
@@ -86,11 +85,6 @@ class SerialPort {
       const buff = Buffer.from(event.data, 'hex');
       listener(buff);
     }
-
-    this.listeners.push({
-      event: DataReceivedEvent,
-      listener: listenerProxy
-    });
     const sub = this.eventEmitter.addListener(DataReceivedEvent, listenerProxy)
     this.subscriptions.push(sub);
     return sub;


### PR DESCRIPTION
Delete the listeners queue, remove the event queue when the early version closes serial port, and now listeners do not have after adding subscriptions queue.